### PR TITLE
Add support for Windows (Scripts folder)

### DIFF
--- a/venv.elv
+++ b/venv.elv
@@ -1,3 +1,4 @@
+use os
 use path
 use re
 use str
@@ -85,7 +86,15 @@ fn activate {
   set venv = (path:abs $venv)
   set-env VIRTUAL_ENV $venv
   set prev[paths] = $paths
-  set paths = [(path:join $venv bin) $@paths]
+
+  # determine correct binary folder name
+  if (os:is-dir (path:join $venv bin)) {
+    set paths = [(path:join $venv bin) $@paths]
+  } elif (os:is-dir (path:join $venv Scripts)) {
+    set paths = [(path:join $venv Scripts) $@paths]
+  } else {
+    fail 'venv: unknown binary directory'
+  }
 
   if (not-eq $E:PYTHONHOME '') {
     set prev[pythonhome] = (get-env PYTHONHOME)
@@ -106,7 +115,6 @@ set edit:completion:arg-completer[venv:activate] = {
     put (pretty-path (path:dir $cfg))
   }
 }
-
 
 set after-chdir = [{|dir|
   for candidate $candidates {


### PR DESCRIPTION
This adds Windows support by checking the structure of the target venv folder: on Windows, the folder has a `Scripts` subfolder rather than a `bin` like other environments.

Therefore, the logic does a quick check if there is a `bin` subfolder to activate the default pathway, else it checks for a `Scripts` subfolder to go down the pathway, and a plain `else` at the end to show a failure message.

All that said, let me know if you want any changes/etc. or of course feel free to directly manipulate the changes.

Resolves #1.